### PR TITLE
The ControlMaster keyword supports 'auto' but its not in the enumerated list.

### DIFF
--- a/config-model-openssh/lib/Config/Model/models/Ssh/HostElement.pl
+++ b/config-model-openssh/lib/Config/Model/models/Ssh/HostElement.pl
@@ -172,6 +172,7 @@ Two additional options allow for opportunistic multiplexing: try to use a master
           'no',
           'yes',
           'ask',
+          'auto',
           'autoask'
         ]
       },


### PR DESCRIPTION
I just added 'auto' to the enumerated list in Ssh/HostElement.pl
