### PR TITLE
fstab: add suid/nosuid

### DIFF
--- a/lib/Config/Model/models/Fstab/CommonOptions.pl
+++ b/lib/Config/Model/models/Fstab/CommonOptions.pl
@@ -36,6 +36,11 @@ return [
         'type' => 'leaf',
         'value_type' => 'boolean'
       },
+      'suid',
+      {
+        'type' => 'leaf',
+        'value_type' => 'boolean'
+      },
       'group',
       {
         'type' => 'leaf',


### PR DESCRIPTION
Mount options suid/nosuid are valid options for many filesystems,
including vfat.